### PR TITLE
Update webdriver

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,6 +27,7 @@ jobs:
         path: |
           ~/.m2
           ~/.sonar/cache
+          ~/.cache/selenium
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml', '**/*.yml') }}
         restore-keys: ${{ runner.os }}-m2-
     - name: Unit and Integration Tests

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
     <dependency>
       <groupId>io.github.bonigarcia</groupId>
       <artifactId>webdrivermanager</artifactId>
-      <version>3.5.0</version>
+      <version>5.0.3</version>
       <scope>test</scope>
     </dependency>
     <!-- https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-testing


### PR DESCRIPTION
Otherwise, in EndeavourOS (Arch) it downloads the wrong version of driver, leading to

```
Multiple Failures (2 failures)
        org.openqa.selenium.SessionNotCreatedException: session not created: This version of ChromeDriver only supports Chrome version 99
Current browser version is 98.0.4758.80 with binary path /opt/google/chrome/google-chrome
Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:17:03'
System info: host: '...', ip: '127.0.1.1', os.name: 'Linux', os.arch: 'amd64', os.version: '5.15.19-1-lts', java.version: '11.0.13'
Driver info: driver.version: ChromeDriver
```